### PR TITLE
cache platform string

### DIFF
--- a/UIDeviceIdentifier/UIDeviceHardware.m
+++ b/UIDeviceIdentifier/UIDeviceHardware.m
@@ -13,12 +13,17 @@
 
 + (NSString *) platform
 {
-    size_t size;
-    sysctlbyname("hw.machine", NULL, &size, NULL, 0);
-    char *machine = malloc(size);
-    sysctlbyname("hw.machine", machine, &size, NULL, 0);
-    NSString *platform = [NSString stringWithUTF8String:machine];
-    free(machine);
+    static dispatch_once_t once;
+    static NSString *platform;
+
+    dispatch_once(&once, ^{
+        size_t size;
+        sysctlbyname("hw.machine", NULL, &size, NULL, 0);
+        char *machine = malloc(size);
+        sysctlbyname("hw.machine", machine, &size, NULL, 0);
+        NSString *platform = [NSString stringWithUTF8String:machine];
+        free(machine);
+    });
 
     return platform;
 }


### PR DESCRIPTION
Hi, platform string is never change while at least app runtime, so it would be better cashing it.

This branch done this by `dispatch_once` singleton. It brings a little performance improvement.