### PR TITLE
added iPhone 6s and iPhone 6s Plus to platform string mapping

### DIFF
--- a/UIDeviceIdentifier/UIDeviceHardware.m
+++ b/UIDeviceIdentifier/UIDeviceHardware.m
@@ -42,6 +42,8 @@
     if ([platform isEqualToString:@"iPhone6,2"])    return @"iPhone 5S (GSM+CDMA)";
     if ([platform isEqualToString:@"iPhone7,1"])    return @"iPhone 6 Plus";
     if ([platform isEqualToString:@"iPhone7,2"])    return @"iPhone 6";
+    if ([platform isEqualToString:@"iPhone8,1"])    return @"iPhone 6s";
+    if ([platform isEqualToString:@"iPhone8,2"])    return @"iPhone 6s Plus";
     if ([platform isEqualToString:@"iPod1,1"])      return @"iPod Touch 1G";
     if ([platform isEqualToString:@"iPod2,1"])      return @"iPod Touch 2G";
     if ([platform isEqualToString:@"iPod3,1"])      return @"iPod Touch 3G";


### PR DESCRIPTION
I only checked it for iPhone 6s, but both should be correct ;)
https://www.theiphonewiki.com/wiki/Models