### PR TITLE
adding NS_ASSUME_NONNULL_BEGIN

### DIFF
--- a/UIDeviceIdentifier/UIDeviceHardware.h
+++ b/UIDeviceIdentifier/UIDeviceHardware.h
@@ -7,6 +7,10 @@
 
 #import <Foundation/Foundation.h>
 
+#ifdef NS_ASSUME_NONNULL_BEGIN
+NS_ASSUME_NONNULL_BEGIN
+#endif
+
 /** UIDeviceHardware as a simple class to allow fetching model descriptions from an iOS device
  */
 @interface UIDeviceHardware : NSObject 
@@ -24,3 +28,7 @@
 + (NSString *) platformString;
 
 @end
+
+#ifdef NS_ASSUME_NONNULL_END
+NS_ASSUME_NONNULL_END
+#endif

--- a/UIDeviceIdentifier/UIDeviceHardware.m
+++ b/UIDeviceIdentifier/UIDeviceHardware.m
@@ -6,7 +6,6 @@
 //
 
 #import "UIDeviceHardware.h"
-#include <sys/types.h>
 #include <sys/sysctl.h>
 
 @implementation UIDeviceHardware


### PR DESCRIPTION
NS_ASSUME_NONNULL_BEGIN was added with Xcode 6.3, but I've protected the inclusion so it works with older Xcode. It is useful when bridging to Swift or when using CLANG_WARN_NULLABLE_TO_NONNULL_CONVERSION.