### PR TITLE
Correct the spelling of CocoaPods in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ UIDeviceHardware is a class originally created in a [gist](https://gist.github.c
 It is written as a class method, to allow use without direct instantiation.
 
 ## Usage
-To use this class, copy the class header files, or include the class in your Cocoapods Podfile. Then when you are ready to query the device, simply import the header file and use:
+To use this class, copy the class header files, or include the class in your CocoaPods Podfile. Then when you are ready to query the device, simply import the header file and use:
 
 ### Podfile inclusion
 


### PR DESCRIPTION

This pull requests corrects the spelling of **CocoaPods** 🤓
https://github.com/CocoaPods/shared_resources/tree/master/media

<blockquote class="twitter-tweet" data-lang="en"><p lang="en" dir="ltr">One day I’ll make a bot that looks through the READMEs of all Pods, looks to see if it uses “Cocoapods” and PRs “CocoaPods” :D</p>&mdash; Ørta (@orta) <a href="https://twitter.com/orta/status/697374357975388160">February 10, 2016</a></blockquote>
<script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>

Created with [`cocoapods-readme`](https://github.com/dkhamsing/cocoapods-readme).  
