### PR TITLE
Fix broken headings in Markdown files

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ pod 'UIDeviceIdentifier', :git => 'https://github.com/squarefrog/UIDeviceIdentif
 ### Code usage
 
 ```objective-c
-#import <UIDeviceIdentifier/UIDeviceHardware.h>
+# import <UIDeviceIdentifier/UIDeviceHardware.h>
 
 @implementation MyClass
 


### PR DESCRIPTION
GitHub changed the way Markdown headings are parsed, so this change fixes it.

See [bryant1410/readmesfix](https://github.com/bryant1410/readmesfix) for more information.

Tackles bryant1410/readmesfix#1
