### PR TITLE
Add Swift Package Manager support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,28 @@
+// swift-tools-version:5.3
+// The swift-tools-version declares the minimum version of Swift required to build this package.
+
+import PackageDescription
+
+let package = Package(
+    name: "UIDeviceIdentifier",
+    products: [
+        // Products define the executables and libraries a package produces, and make them visible to other packages.
+        .library(
+            name: "UIDeviceIdentifier",
+            targets: ["UIDeviceIdentifier"]
+        ),
+    ],
+    dependencies: [
+        // Dependencies declare other packages that this package depends on.
+        // .package(url: /* package url */, from: "1.0.0"),
+    ],
+    targets: [
+        // Targets are the basic building blocks of a package. A target can define a module or a test suite.
+        // Targets can depend on other targets in this package, and on products in packages this package depends on.
+        .target(
+            name: "UIDeviceIdentifier",
+            dependencies: [],
+            path: "UIDeviceIdentifier",
+            publicHeadersPath: "."),
+    ]
+)

--- a/README.md
+++ b/README.md
@@ -4,30 +4,61 @@ UIDeviceHardware is a class originally created in a [gist](https://gist.github.c
 It is written as a class method, to allow use without direct instantiation.
 
 ## Usage
-To use this class, copy the class header files, or include the class in your CocoaPods Podfile. Then when you are ready to query the device, simply import the header file and use:
 
-### Podfile inclusion
+```objective-c
 
+// "iPhone 5C (GSM)"
+NSString *platformString = [UIDeviceHardware platformString];
+    
+// "iPhone 5C"
+NSString *simpleString = [UIDeviceHardware platformStringSimple];
+```
+
+## Installation
+
+This class can be installed with **Swift Package Manager**, **Cocoapods**, or by **directly copying the files** into your source code.
+
+### Swift Package Manager
+
+Add the package to your Package.swift file:
+
+```swift
+dependencies: [
+    .package(url: "https://github.com/squarefrog/UIDeviceIdentifier", .upToNextMajor(from: "1.7.0"))
+],
+```
+
+Then import as follows:
+```objective-c
+// ObjC
+@import UIDeviceIdentifier;
+```
+
+```swift
+// Swift
+import UIDeviceIdentifier
+```
+
+### Cocoapods
+
+Add the cocoapod to your Podfile:
 ```ruby
 pod 'UIDeviceIdentifier', :git => 'https://github.com/squarefrog/UIDeviceIdentifier.git'
 ```
 
-### Code usage
-
+Import the file into your Objective-C file:
 ```objective-c
+// ObjC
 #import <UIDeviceIdentifier/UIDeviceHardware.h>
-
-@implementation MyClass
-
-- (void)myMethod
-{
-
-    NSString *platformString = [UIDeviceHardware platformString];
-    NSString *currentDevice = [UIDeviceHardware platformString];
-}
-
-@end
 ```
 
-## Licence
+### Copying the files
+
+Copy `UIDeviceHardware.{h/m}` into your project. Then just import the header:
+
+```objective-c
+#import "UIDeviceHardware.h"
+```
+
+## License
 UIDeviceHardware is available under the MIT license. See the LICENSE file for more info.


### PR DESCRIPTION
This PR adds Swift Package Manager support. I updated the README as well to describe how to install it. Note that the readme references version "1.7.0". This doesn't exist yet, but I'm assuming that the next release to include the SPM support would be version 1.7.0. I'm happy to adjust the version number in the readme as desired.